### PR TITLE
Update sharing on X

### DIFF
--- a/vite/VideoPage/Actions/SharingActions.tsx
+++ b/vite/VideoPage/Actions/SharingActions.tsx
@@ -7,7 +7,7 @@ import { SharingAction } from "./SharingAction";
 import styles from "./styles.module.css";
 
 export const twitterSharingLink = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
-  "This is my #GitHubUnwrapped! Get your own: https://www.githubunwrapped.com\n\n[DELETE THIS PLACEHOLDER, DOWNLOAD AND DRAG YOUR MP4 VIDEO IN HERE]",
+  "This is my #GitHubUnwrapped! Get your own: https://www.githubunwrapped.com",
 )}`;
 
 export const linkedInSharingLink = "https://www.linkedin.com/";

--- a/vite/VideoPage/Actions/SharingActions.tsx
+++ b/vite/VideoPage/Actions/SharingActions.tsx
@@ -7,7 +7,7 @@ import { SharingAction } from "./SharingAction";
 import styles from "./styles.module.css";
 
 export const twitterSharingLink = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
-  "This is my #GitHubUnwrapped! Get your own: https://www.githubunwrapped.com\n\n[Delete this placeholder, download and drag your MP4 video in here]",
+  "This is my #GitHubUnwrapped! Get your own: https://www.githubunwrapped.com\n\n[DELETE THIS PLACEHOLDER, DOWNLOAD AND DRAG YOUR MP4 VIDEO IN HERE]",
 )}`;
 
 export const linkedInSharingLink = "https://www.linkedin.com/";


### PR DESCRIPTION
I went with this version, to make it more obvious that people have to upload the video by themselves, and need to delete the text/placeholder.

Refers to issue/task #50 on the Kanban.

![Screenshot 2023-12-11 at 14 35 17](https://github.com/remotion-dev/github-unwrapped-2023/assets/86873911/49a52359-ae32-4ba8-8bb5-4a7a4fcec007)
