### PR TITLE
Update from 2024 to 2025

### DIFF
--- a/remotion/Contributions/index.tsx
+++ b/remotion/Contributions/index.tsx
@@ -228,7 +228,7 @@ export const ContributionsScene: React.FC<{
               }}
             >
               <div style={{ textAlign: "left", paddingLeft: 10 }}>
-                <ContributionNumber currentNumber={2024} suffix="" />
+                <ContributionNumber currentNumber={2025} suffix="" />
                 <ContributionLabel>@{username}</ContributionLabel>
               </div>
               <div style={{ flex: 1 }} />

--- a/remotion/IGStory/GraphData.tsx
+++ b/remotion/IGStory/GraphData.tsx
@@ -77,7 +77,7 @@ export const ContributionGraphic: React.FC<{
           paddingLeft: 20,
         }}
       >
-        <Stat align="left" data={2024} label={login} />
+        <Stat align="left" data={2025} label={login} />
         <div style={{ flex: 1 }} />
         <Stat align="right" data={longestStreak} label="Longest streak" />
         <div style={{ width: 30 }} />

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import { zColor } from "@remotion/zod-types";
 import { random } from "remotion/no-react";
 import { z } from "zod";
 
-export const SITE_NAME = `unwrapped2024`;
+export const SITE_NAME = `unwrapped2025`;
 export const RAM = 1200;
 export const DISK = 10240;
 export const TIMEOUT = 120;

--- a/src/helpers/year.ts
+++ b/src/helpers/year.ts
@@ -1,1 +1,1 @@
-export const YEAR_TO_REVIEW = 2024;
+export const YEAR_TO_REVIEW = 2025;

--- a/src/server/year.ts
+++ b/src/server/year.ts
@@ -1,1 +1,1 @@
-export const YEAR_TO_REVIEW = 2024;
+export const YEAR_TO_REVIEW = 2025;


### PR DESCRIPTION
Changed all hardcoded year values and site name from 2024 to 2025 in configuration, helper, server, and UI components to prepare for the new review period.