### PR TITLE
fix: remove duplicate weekdays in productivity wheel

### DIFF
--- a/remotion/Productivity/Productivity.tsx
+++ b/remotion/Productivity/Productivity.tsx
@@ -136,8 +136,6 @@ export const Productivity: React.FC<Props> = ({ graphData, weekday, hour }) => {
           "Tuesday",
           "Wednesday",
           "Thursday",
-          "Wednesday",
-          "Thursday",
           "Friday",
           "Saturday",
           "Sunday",


### PR DESCRIPTION
## Summary

- The weekday `values` array in the "Most productive day" wheel had **9 entries instead of 7** — Wednesday and Thursday were duplicated
- This caused the `Wheel` component to render 9 slots with incorrect angular distribution (40° per slot instead of 51.4°), resulting in uneven spacing in the animation

## Change

Removed the two duplicate entries in `remotion/Productivity/Productivity.tsx:136-137`.

## Test plan

- [ ] Run `npx remotion studio` and verify the "Most productive day" wheel renders 7 evenly-spaced weekday labels
- [ ] Verify the wheel stops on the correct weekday for different `topWeekday` values ("0" through "6")

🤖 Generated with [Claude Code](https://claude.com/claude-code)